### PR TITLE
fix: replace broken registry links, github.io links, and stale repo names in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@
 
 # Azure NoOps Terraform Baseline
 
-[![ci](https://github.com/POps-Rox/terraform-baseline/actions/workflows/ci.yml/badge.svg)](hhttps://github.com/POps-Rox/terraform-baseline/actions/workflows/ci.yml)
-
 Azure NoOps Terraform Baseline Guide (ETB) is a collection of tutorials amd guides on how to get started with Terraform in Azure NoOps.
 
-Hosted in [GitHub Pages](https://POps-Rox.github.io/terraform-overlays-baseline/).
+Documentation and guides are hosted in this [GitHub repository](https://github.com/POps-Rox/terraform-overlays-baseline).
 
 ## Development
 

--- a/docs/basics/noops/create-resources.md
+++ b/docs/basics/noops/create-resources.md
@@ -271,8 +271,8 @@ Let's create an Azure Storage account using Terraform:
 
     ```terraform
     module "mod_vnet_spoke" {
-      source  = "POps-Rox/overlays-workload-spoke/azurerm"
-      version = "~> 1.0.0"
+      source  = "github.com/POps-Rox/terraform-az-overlays-workloadspoke"
+      # version: pin with ?ref=v1.0.0 in source URL — Terraform Registry publication pending
 
       # By default, this module will create a resource group, provide the name here
       # To use an existing resource group, specify the existing resource group name, 
@@ -332,8 +332,8 @@ Let's create an Azure Storage account using Terraform:
 <details><summary>Show `modules.spoke.tf` contents</summary>
     ```console
     module "mod_vnet_spoke" {
-      source  = "POps-Rox/overlays-workload-spoke/azurerm"
-      version = "~> 1.0.0"
+      source  = "github.com/POps-Rox/terraform-az-overlays-workloadspoke"
+      # version: pin with ?ref=v1.0.0 in source URL — Terraform Registry publication pending
 
       # By default, this module will create a resource group, provide the name here
       # To use an existing resource group, specify the existing resource group name, 
@@ -397,8 +397,8 @@ Let's create an Azure Storage account using Terraform:
 
     ```terraform
     module "mod_storage_account" "example" {
-      source="pops-rox/terraform-azurerm-overlays-storage-account/azurerm"
-      version="0.1.0"
+      source  = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
+      # version: pin with ?ref=v0.1.0 in source URL — Terraform Registry publication pending
 
       # Resource Group, location, VNet and Subnet details
       create_storage_resource_group = true
@@ -448,8 +448,8 @@ Let's create an Azure Storage account using Terraform:
     ```console
 
     module "mod_storage_account" "example" {
-      source="pops-rox/terraform-azurerm-overlays-storage-account/azurerm"
-      version="0.1.0"
+      source  = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
+      # version: pin with ?ref=v0.1.0 in source URL — Terraform Registry publication pending
 
       # Resource Group, location, VNet and Subnet details
       create_storage_resource_group = true

--- a/docs/basics/noops/syntax.md
+++ b/docs/basics/noops/syntax.md
@@ -53,10 +53,12 @@ module "mod_<module>" "<name>" {
 
 For example:
 
+> **Note:** POps-Rox modules are not yet published to the Terraform Registry. Use the GitHub source format shown below until registry publication is complete.
+
 ```terraform
 module "mod_storage_account" "example" {
-  source="pops-rox/terraform-azurerm-overlays-storage-account/azurerm"
-  version="0.1.0"
+  source  = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
+  # version: pin with ?ref=v0.1.0 in source URL — Terraform Registry publication pending
   name                     = "examplest"  
   location                 = "northeurope"
   account_tier             = "Standard"
@@ -94,8 +96,8 @@ data "azurerm_resource_group" "example" {
 }
 
 module "mod_storage_account" "example" {
-  source="pops-rox/terraform-azurerm-overlays-storage-account/azurerm"
-  version="0.1.0"
+  source  = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
+  # version: pin with ?ref=v0.1.0 in source URL — Terraform Registry publication pending
   
   existing_resource_group_name   = data.azurerm_resource_group.example.name
   location                       = data.azurerm_resource_group.example.location

--- a/docs/best-practices/code-structure.md
+++ b/docs/best-practices/code-structure.md
@@ -8,7 +8,7 @@ In Azure NoOps overlay modules, the Terraform configurations are structured in t
 
 resources.`azure_resource`.tf - contains the resources that are created in the module and the configuration of those resources. Example: resources.key.vault.tf
 
-modules.`azure_resource`.tf - contains the NoOps modules that are used in the module. Example: modules.key.vault.tf which is the [Key Vault module](https://github.com/POps-Rox/terraform-azurerm-overlays-key-vault).
+modules.`azure_resource`.tf - contains the NoOps modules that are used in the module. Example: modules.key.vault.tf which is the [Key Vault module](https://github.com/POps-Rox/terraform-az-overlays-keyvault).
 
 variables.`azure_resource`.tf - contains declarations of variables used in resources.tf
 

--- a/docs/best-practices/key-concepts.md
+++ b/docs/best-practices/key-concepts.md
@@ -8,7 +8,7 @@ A Resource is an instantiation of an Azure resource such as a azurerm_storage_ac
 
 ## Resource module (aka Overlay Module)
 
-A Resource Module which is commonly called an `Overlay` in the Azure NoOps ecosystem is a collection of connected resources which together perform a common action (For example, [Azure NoOps Storage Account Terraform Overlays Module](https://github.com/POps-Rox/terraform-azurerm-overlays-storage-account) creates Storage Account, blobs, tables, etc). It depends on provider configuration, which can be defined in it, or in higher-level structures (e.g. in infrastructure module).
+A Resource Module which is commonly called an `Overlay` in the Azure NoOps ecosystem is a collection of connected resources which together perform a common action (For example, [Azure NoOps Storage Account Terraform Overlays Module](https://github.com/POps-Rox/terraform-az-overlays-storageaccount) creates Storage Account, blobs, tables, etc). It depends on provider configuration, which can be defined in it, or in higher-level structures (e.g. in infrastructure module).
 
 ## Infrastructure module
 
@@ -16,13 +16,13 @@ An Infrastructure Module is a collection of resources and/or resource modules, w
 
 Infrastructure module can include multiple Overlay Modules, provider resources, and data sources. While an "`Overlay`" is not necessarily an "Infrastructure module", an infrastructure module can include multiple Overlay Modules, which in turn can be called an `Overlay`. Basically anything that can be used to create a resource or a resource module can be included in an `Overlay`.
 
-For example, [terraform-azurerm-overlays-management-hub](https://github.com/POps-Rox/terraform-azurerm-overlays-management-hub) overlay module includes provider resources like [azurerm_virtual_network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network), [azurerm_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet), and includes resource modules(`Overlay` modules)[terraform-azurerm-overlays-storage-account](https://github.com/POps-Rox/terraform-azurerm-overlays-storage-account),[terraform-azurerm-overlays-management-logging](https://github.com/POps-Rox/terraform-azurerm-overlays-management-logging) to manage the infrastructure required for running [Landing Zone Management Hub](https://github.com/POps-Rox/terraform-azurerm-overlays-management-hub) on Azure NoOps Mission Enclave.
+For example, [terraform-az-overlays-managementhub](https://github.com/POps-Rox/terraform-az-overlays-managementhub) overlay module includes provider resources like [azurerm_virtual_network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network), [azurerm_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet), and includes resource modules(`Overlay` modules)[terraform-az-overlays-storageaccount](https://github.com/POps-Rox/terraform-az-overlays-storageaccount),[terraform-az-overlays-managementlogging](https://github.com/POps-Rox/terraform-az-overlays-managementlogging) to manage the infrastructure required for running [Landing Zone Management Hub](https://github.com/POps-Rox/terraform-az-overlays-managementhub) on Azure NoOps Mission Enclave.
 
 ## Composition
 
 A Composition is a collection of infrastructure modules(`Overlays`), which can span across several logically separated areas (e.g. Azure Regions, several Azure accounts). A Composition is used to describe the complete infrastructure required for the whole organization or project.
 
-A Composition consists of infrastructure modules, which consist of resources modules, which implement individual resources. For example, the [Mission Enclave Landing Zone Starter](https://github.com/POps-Rox/ref-scca-enclave-landing-zone-starter) is a composition that consists of the [Landing Zone Management Hub](https://github.com/POps-Rox/terraform-azurerm-overlays-management-hub) and [Landing Zone Management Spoke](https://github.com/POps-Rox/terraform-azurerm-overlays-management-spoke) infrastructure modules.
+A Composition consists of infrastructure modules, which consist of resources modules, which implement individual resources. For example, the [Mission Enclave Landing Zone Starter](https://github.com/POps-Rox/ref-scca-enclave-landing-zone-starter) is a composition that consists of the [Landing Zone Management Hub](https://github.com/POps-Rox/terraform-az-overlays-managementhub) and [Landing Zone Management Spoke](https://github.com/POps-Rox/terraform-az-overlays-managementspoke) infrastructure modules.
 
 ## Data Source
 
@@ -44,7 +44,7 @@ Providers, provisioners, and a few other terms are described very well in the of
 
 ## Putting it all together
 
-Think of individual resources like atoms in the infrastructure, Resource Modules are molecules (consisting of atoms). A Module is the smallest versioned and shareable unit. It has an exact list of arguments, implements basic logic for such a unit to do the required function. e.g. terraform-azurerm-overlays-key-vault module creates azurerm_keyvault and azurerm_keyvault_access_policy resources based on input. This resource module by itself can be used together with other modules to create the infrastructure module.
+Think of individual resources like atoms in the infrastructure, Resource Modules are molecules (consisting of atoms). A Module is the smallest versioned and shareable unit. It has an exact list of arguments, implements basic logic for such a unit to do the required function. e.g. terraform-az-overlays-keyvault module creates azurerm_keyvault and azurerm_keyvault_access_policy resources based on input. This resource module by itself can be used together with other modules to create the infrastructure module.
 
 Access to data across molecules (Resource Modules and Infrastructure Modules) is performed using the modules' outputs and data sources.
 
@@ -57,19 +57,19 @@ composition-1 (Mission Enclave Landing Zone Starter) {
   infrastructure-module-1 (Landing Zone Management Hub) {
     data-source-1 (Lookup for Resource Group) => d1
 
-    resource-module-1 (terraform-azurerm-overlays-storage-account) (Storage Account, blobs, tables, etc) {
+    resource-module-1 (terraform-az-overlays-storageaccount) (Storage Account, blobs, tables, etc) {
       data-source-2 => d2
       resource-1 (azurerm_storage_account, d2)
       resource-2 (azurerm_storage_container, d2)
     }
 
-    resource-module-2 (terraform-azurerm-overlays-logging) (Log Analytics, Storage Account, etc) {
+    resource-module-2 (terraform-az-overlays-managementlogging) (Log Analytics, Storage Account, etc) {
       data-source-3 => d3
       resource-3 (azurerm_log_analytics_workspace, d3)
-      resource-module-4 (terraform-azurerm-overlays-storage-account)
+      resource-module-4 (terraform-az-overlays-storageaccount)
     }
 
-    resource-module-3 (terraform-azurerm-overlays-key-vault) (Key Vault, access policy, etc) {
+    resource-module-3 (terraform-az-overlays-keyvault) (Key Vault, access policy, etc) {
       data-source-4 => d34
       resource-5 (azurerm_key_vault, d4)
       resource-6 (azurerm_key_vault_access_policy, d4)

--- a/docs/best-practices/naming-conventions.md
+++ b/docs/best-practices/naming-conventions.md
@@ -128,7 +128,8 @@ module "example" {
     b = "b",
     c = "c"
   } : {}
-  source = "pops-rox/ovarlays-storage-account/azurerm"
+  source = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
+  # Note: Terraform Registry publication pending; use GitHub source for now
   version = "~> 3.0.0"
   name                  = "${var.create_storage_account ? "example" : "none"}-${each.key}"
   location              = azurerm_resource_group.example.location

--- a/docs/best-practices/naming-conventions.md
+++ b/docs/best-practices/naming-conventions.md
@@ -129,8 +129,7 @@ module "example" {
     c = "c"
   } : {}
   source = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
-  # Note: Terraform Registry publication pending; use GitHub source for now
-  version = "~> 3.0.0"
+  # Note: Terraform Registry publication pending; pin with ?ref=v3.0.0 in source URL
   name                  = "${var.create_storage_account ? "example" : "none"}-${each.key}"
   location              = azurerm_resource_group.example.location
   resource_group_name   = azurerm_resource_group.example.name

--- a/docs/deployment/policy/policy-planning.md
+++ b/docs/deployment/policy/policy-planning.md
@@ -54,7 +54,7 @@ Parameter name | Default Value | Description
 
 - Should be Defined as **high up** in the hierarchy as possible.
 - Should be Assigned as **low down** in the hierarchy as possible.
-- Multiple scopes can be exempt from policy inheritance by specifying `assignment_not_scopes` or using the [Azure NoOps Policy Exemption module](https://github.com/POps-Rox/terraform-azurerm-overlays-policy/tree/main/modules/policyExemption).
+- Multiple scopes can be exempt from policy inheritance by specifying `assignment_not_scopes` or using the [Azure NoOps Policy Exemption module](https://github.com/POps-Rox/terraform-az-overlays-policy/tree/main/modules/policyExemption).
 - Policy **overrides RBAC** so even resource owners and contributors fall under compliance enforcements assigned at a higher scope (unless the policy is assigned at the ownership scope).
 
 ![Policy Definition and Assignment Scopes](img/scopes.png)

--- a/docs/deployment/policy/policy-remediation.md
+++ b/docs/deployment/policy/policy-remediation.md
@@ -12,7 +12,7 @@ Automatic remediation involves using automation tools to identify and correct no
 
 Automatic remediation is often used for critical or recurring issues that require immediate attention. It can help ensure that non-compliant resources are corrected quickly and consistently, reducing the risk of security breaches and compliance violations.
 
-[Azure NoOps Policy Module](https://github.com/POps-Rox/terraform-azurerm-overlays-policy) provides a set of policy definitions, initatives and remediation tasks that can be used to automatically remediate non-compliant resources in Azure. These policy definitions and remediation tasks are designed to help organizations enforce security and compliance standards across their Azure environment.
+[Azure NoOps Policy Module](https://github.com/POps-Rox/terraform-az-overlays-policy) provides a set of policy definitions, initatives and remediation tasks that can be used to automatically remediate non-compliant resources in Azure. These policy definitions and remediation tasks are designed to help organizations enforce security and compliance standards across their Azure environment.
 
 ## Best Practices for Policy Remediation
 

--- a/docs/developing-modules/overview.md
+++ b/docs/developing-modules/overview.md
@@ -6,9 +6,9 @@ This document provides best practices for developing reusable Terraform modules 
 
 - Use [this template](https://github.com/POps-Rox/terraform-module-overlays-template) when creating your repository.
 
-- Use the common naming convention `terraform-azurerm-overlays-<name>` when naming your repository.
+- Use the common naming convention `terraform-az-overlays-<name>` when naming your repository.
 
-    For example, if you want to create a module named `storage`, the repository should be named `terraform-azurerm-overlays-storage`.
+    For example, if you want to create a module named `storage`, the repository should be named `terraform-az-overlays-storage`.
 
 - Configure the following code owners in a file `.github/CODEOWNERS`:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,11 +8,9 @@
 
 # Azure NoOps Terraform Baseline
 
-[![ci](https://github.com/POps-Rox/terraform-baseline/actions/workflows/ci.yml/badge.svg)](hhttps://github.com/POps-Rox/terraform-baseline/actions/workflows/ci.yml)
-
 Azure NoOps Terraform Baseline Guide (ETB) is a collection of tutorials amd guides on how to get started with Terraform in Azure NoOps.
 
-Hosted in [GitHub Pages](https://POps-Rox.github.io/terraform-overlays-baseline/).
+Documentation and guides are hosted in this [GitHub repository](https://github.com/POps-Rox/terraform-overlays-baseline).
 
 ## Development
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,7 +73,7 @@ nav:
       - basics/noops/destroy-resources.md
       - basics/noops/summary.md
   - Reusable Modules:
-    - Module library: https://registry.terraform.io/search/modules?namespace=pops-rox&provider=azure
+    - Module library: https://github.com/orgs/POps-Rox/repositories?q=terraform-az-overlays&type=public
   - Developing Modules:
     - Overview: developing-modules/overview.md
     - Module structure: developing-modules/module-structure.md


### PR DESCRIPTION
## Summary
Fixes all broken links identified in issues #2 and #3.

## Changes
- **README.md / docs/index.md**: Remove stale duplicate CI badge (hhttps:// typo), replace broken GitHub Pages link with GitHub repo link
- **mkdocs.yml**: Replace empty Terraform Registry search nav with working GitHub org filter
- **docs/basics/noops/syntax.md**: Replace unpublished registry module sources with GitHub sources + note callout
- **docs/basics/noops/create-resources.md**: Same fix for workload-spoke and storage-account module sources
- **docs/best-practices/naming-conventions.md**: Fix registry source + ovarlays typo
- **docs/best-practices/code-structure.md**: Fix 404 terraform-azurerm-overlays-key-vault link
- **docs/best-practices/key-concepts.md**: Fix 5 broken terraform-azurerm-overlays-* GitHub links
- **docs/developing-modules/overview.md**: Update naming convention guidance to terraform-az-overlays-* pattern
- **docs/deployment/policy/**: Fix 404 terraform-azurerm-overlays-policy links

All changes are documentation-only. No .tf infrastructure files affected.

Closes #2
Closes #3